### PR TITLE
More topologies

### DIFF
--- a/Assets/Editor/ModelInspector.cs
+++ b/Assets/Editor/ModelInspector.cs
@@ -403,7 +403,14 @@ namespace UnityEditor
                 if (meshSubset < 0 || meshSubset >= submeshes)
                 {
                     for (int i = 0; i < submeshes; ++i)
+                    {
+                        // lines/points already are wire-like; it does not make sense to overdraw
+                        // them again with dark wireframe color
+                        var topology = mesh.GetTopology(i);
+                        if (topology == MeshTopology.Lines || topology == MeshTopology.LineStrip || topology == MeshTopology.Points)
+                            continue;
                         previewUtility.DrawMesh(mesh, pos, rot, wireMaterial, i, customProperties);
+                    }
                 }
                 else
                     previewUtility.DrawMesh(mesh, pos, rot, wireMaterial, meshSubset, customProperties);


### PR DESCRIPTION
- Fixed submesh display for Line/Point topologies, and tweaked format of the info
- For lines/points meshes, don't overdraw with dark wireframe again, since it's barely visible

<img width="387" alt="Screen Shot 2019-12-04 at 3 18 57 PM" src="https://user-images.githubusercontent.com/348087/70146053-13c2b400-16aa-11ea-9e63-d9d5561a9c3f.png">
<img width="329" alt="Screen Shot 2019-12-04 at 3 19 03 PM" src="https://user-images.githubusercontent.com/348087/70146057-16250e00-16aa-11ea-97b5-76f4f064ce9c.png">
<img width="258" alt="Screen Shot 2019-12-04 at 3 24 17 PM" src="https://user-images.githubusercontent.com/348087/70146084-2806b100-16aa-11ea-8dff-a3202a557d21.png">
