### PR TITLE
Fix outline not matching up when at 150% display zoom

### DIFF
--- a/Assets/Editor/ModelInspector.cs
+++ b/Assets/Editor/ModelInspector.cs
@@ -629,9 +629,9 @@ namespace UnityEditor
             EditorGUI.DrawRect(rect, color);
             var dimmed = color * new Color(0.2f, 0.2f, 0.2f, 0.5f);
             EditorGUI.DrawRect(new Rect(rect.x, rect.y, 1, rect.height), dimmed);
-            EditorGUI.DrawRect(new Rect(rect.x + rect.width - 1, rect.y, 1, rect.height), dimmed);
-            EditorGUI.DrawRect(new Rect(rect.x + 1, rect.y, rect.width - 2, 1), dimmed);
-            EditorGUI.DrawRect(new Rect(rect.x + 1, rect.y + rect.height - 1, rect.width - 2, 1), dimmed);
+            EditorGUI.DrawRect(new Rect(rect.x + rect.width-1, rect.y, 1, rect.height), dimmed);
+            EditorGUI.DrawRect(new Rect(rect.x, rect.y, rect.width, 1), dimmed);
+            EditorGUI.DrawRect(new Rect(rect.x, rect.y + rect.height-1, rect.width, 1), dimmed);
         }
 
         public override void OnInspectorGUI()


### PR DESCRIPTION
Something in IMGUI apparently rounds some stuff up somewhere and leaves gaps when it should not. Before: 
![Clipboard01](https://user-images.githubusercontent.com/348087/70317217-02061b80-1826-11ea-9f13-d7699a4087c5.png)


And after:
![Clipboard02](https://user-images.githubusercontent.com/348087/70317222-06cacf80-1826-11ea-9d9e-fe3e8b08edda.png)
